### PR TITLE
 #14 added PID PPID and COMM info

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,10 @@ Notice that we have to specify the parameter data types. <i>(You can use `weaver
 Now we can call `weaver` like so:
 
 ```
-sudo ./bin/weaver -f ./cmd/test-prog/test_functions_file.txt ./bin/test-prog
+sudo weaver -f /path/to/functions_to_trace.txt /path/to/test-prog-binary
 ```
 
-
-Weaver will then sit idle without any output until `test-prog` is run and the `test_function` function is called. This will also work on a running Go Program.
+Weaver will then sit idle without any output until `test-prog` is run and the `test_function` and `other_test_function` functions are called. This will also work on an already running Go Program.
 
 ```
 +--------------------+--------------+-----------+-------+

--- a/cmd/weaver/load_uprobe.go
+++ b/cmd/weaver/load_uprobe.go
@@ -153,9 +153,10 @@ func loadUprobeAndBPFModule(traceContext *functionTraceContext, runtimeContext c
 		for {
 			// First sent values are process info
 			value := <-channel
-			output.ProcInfo = procInfo{}
-			err := output.ProcInfo.unmarshalBinary(value)
+			procInfo := procInfo{}
+			err := procInfo.unmarshalBinary(value)
 			if err == nil {
+				output.ProcInfo = procInfo
 				// if err == nil value was proc info struct, else do
 				// not fetch next value
 				value = <-channel

--- a/cmd/weaver/load_uprobe.go
+++ b/cmd/weaver/load_uprobe.go
@@ -16,11 +16,29 @@ import (
 const bpfProgramTextTemplate = `
 	#include <uapi/linux/ptrace.h>
 	#include <linux/string.h>
+	#include <linux/fs.h>
+	#include <linux/sched.h>
 
 	BPF_PERF_OUTPUT(events);
 
+	struct proc_info_t {
+    	u32 pid;  // PID as in the userspace term (i.e. task->tgid in kernel)
+    	u32 ppid; // Parent PID as in the userspace term (i.e task->real_parent->tgid in kernel)
+    	char comm[TASK_COMM_LEN]; // 16 bytes
+	};
+
 	inline int print_symbol_arg(struct pt_regs *ctx) {
 		
+		// get process info
+    	struct task_struct *task;
+		struct proc_info_t procInfo = {};
+    	task = (struct task_struct *)bpf_get_current_task();
+		procInfo.pid = bpf_get_current_pid_tgid() >> 32;
+		procInfo.ppid = task->real_parent->tgid;
+		bpf_get_current_comm(&procInfo.comm, sizeof(procInfo.comm));
+
+		events.perf_submit(ctx, &procInfo, sizeof(procInfo));
+
 		void* stackAddr = (void*)ctx->sp;
 		{{range $arg_index, $arg_element := .Arguments}}
 
@@ -129,6 +147,13 @@ func loadUprobeAndBPFModule(traceContext *functionTraceContext, runtimeContext c
 	output := output{FunctionName: traceContext.FunctionName}
 	var argOutput = make([]outputArg, numberOfArgs)
 	go func() {
+		// First sent values are process info
+		value := <-channel
+		output.ProcInfo = procInfo{}
+		err := output.ProcInfo.UnmarshalBinary(value)
+		if err != nil {
+			fmt.Println("failed to unmarshall process info")
+		}
 
 		var valueString string
 		var outputValue outputArg

--- a/cmd/weaver/load_uprobe.go
+++ b/cmd/weaver/load_uprobe.go
@@ -22,17 +22,17 @@ const bpfProgramTextTemplate = `
 	BPF_PERF_OUTPUT(events);
 
 	struct proc_info_t {
-    	u32 pid;  // PID as in the userspace term (i.e. task->tgid in kernel)
-    	u32 ppid; // Parent PID as in the userspace term (i.e task->real_parent->tgid in kernel)
-    	char comm[TASK_COMM_LEN]; // 16 bytes
+		u32 pid;  // PID as in the userspace term (i.e. task->tgid in kernel)
+		u32 ppid; // Parent PID as in the userspace term (i.e task->real_parent->tgid in kernel)
+		char comm[TASK_COMM_LEN]; // 16 bytes
 	};
 
 	inline int print_symbol_arg(struct pt_regs *ctx) {
 		
 		// get process info
-    	struct task_struct *task;
+		struct task_struct *task;
 		struct proc_info_t procInfo = {};
-    	task = (struct task_struct *)bpf_get_current_task();
+		task = (struct task_struct *)bpf_get_current_task();
 		procInfo.pid = bpf_get_current_pid_tgid() >> 32;
 		procInfo.ppid = task->real_parent->tgid;
 		bpf_get_current_comm(&procInfo.comm, sizeof(procInfo.comm));

--- a/cmd/weaver/load_uprobe.go
+++ b/cmd/weaver/load_uprobe.go
@@ -147,18 +147,20 @@ func loadUprobeAndBPFModule(traceContext *functionTraceContext, runtimeContext c
 	output := output{FunctionName: traceContext.FunctionName}
 	var argOutput = make([]outputArg, numberOfArgs)
 	go func() {
-		// First sent values are process info
-		value := <-channel
-		output.ProcInfo = procInfo{}
-		err := output.ProcInfo.unmarshalBinary(value)
-		if err != nil {
-			fmt.Println("failed to unmarshall process info")
-		}
 
 		var valueString string
 		var outputValue outputArg
 		for {
+			// First sent values are process info
 			value := <-channel
+			output.ProcInfo = procInfo{}
+			err := output.ProcInfo.unmarshalBinary(value)
+			if err != nil {
+				// assume it is not proc info struct
+				fmt.Println("failed to unmarshall process info")
+			} else {
+				value = <-channel
+			}
 
 			// Determine what type it is for interpretation based on order of value coming in
 			dataTypeOfValue = traceContext.Arguments[index].goType

--- a/cmd/weaver/load_uprobe.go
+++ b/cmd/weaver/load_uprobe.go
@@ -155,10 +155,9 @@ func loadUprobeAndBPFModule(traceContext *functionTraceContext, runtimeContext c
 			value := <-channel
 			output.ProcInfo = procInfo{}
 			err := output.ProcInfo.unmarshalBinary(value)
-			if err != nil {
-				// assume it is not proc info struct
-				fmt.Println("failed to unmarshall process info")
-			} else {
+			if err == nil {
+				// if err == nil value was proc info struct, else do
+				// not fetch next value
 				value = <-channel
 			}
 

--- a/cmd/weaver/output.go
+++ b/cmd/weaver/output.go
@@ -12,6 +12,7 @@ import (
 type output struct {
 	FunctionName string
 	Args         []outputArg
+	ProcInfo     procInfo `json:"procInfo,omitempty"`
 }
 
 type outputArg struct {
@@ -33,10 +34,11 @@ func printOutput(o output) error {
 	}
 
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"Function Name", "Arg Position", "Type", "Value"})
+	table.SetHeader([]string{"Function Name", "Arg Position", "Type", "Value", "Proc Name", "PID", "PPID"})
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
 	for i, arg := range o.Args {
-		line := []string{o.FunctionName, fmt.Sprintf("%d", i), arg.Type, arg.Value}
+		line := []string{o.FunctionName, fmt.Sprintf("%d", i), arg.Type, arg.Value, o.ProcInfo.Comm,
+			fmt.Sprintf("%d", o.ProcInfo.Pid), fmt.Sprintf("%d", o.ProcInfo.Ppid)}
 		table.Append(line)
 	}
 

--- a/cmd/weaver/types.go
+++ b/cmd/weaver/types.go
@@ -39,7 +39,6 @@ func (i *procInfo) unmarshalBinary(data []byte) error {
 	if len(data) > 24 || len(data) < 8 {
 		return fmt.Errorf("error decoding process info")
 	}
-	fmt.Println(len(data))
 	i.Pid = binary.LittleEndian.Uint32(data[0:4])
 	i.Ppid = binary.LittleEndian.Uint32(data[4:8])
 	i.Comm = string(data[8:])

--- a/cmd/weaver/types.go
+++ b/cmd/weaver/types.go
@@ -35,10 +35,11 @@ type procInfo struct {
 func (i *procInfo) unmarshalBinary(data []byte) error {
 
 	data = bytes.Trim(data, "\x00")
-	// proc info struct is 24 bytes long
-	if len(data) == 24 {
+	// proc info struct is 24 bytes long and should at least be 8 bytes long
+	if len(data) > 24 || len(data) < 8 {
 		return fmt.Errorf("error decoding process info")
 	}
+	fmt.Println(len(data))
 	i.Pid = binary.LittleEndian.Uint32(data[0:4])
 	i.Ppid = binary.LittleEndian.Uint32(data[4:8])
 	i.Comm = string(data[8:])

--- a/cmd/weaver/types.go
+++ b/cmd/weaver/types.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"strconv"
@@ -21,6 +23,27 @@ type argument struct {
 	PrintfFormat   string
 	TypeSize       int
 	ArrayLength    int // Set as 0 if not array
+}
+
+type procInfo struct {
+	Pid  uint32 `json:"pid,omitempty"`
+	Ppid uint32 `json:"ppid,omitempty"`
+	Comm string `json:"comm,omitempty"`
+}
+
+// UnmarshalBinary for procInfo
+func (i *procInfo) UnmarshalBinary(data []byte) error {
+
+	// proc info struct is 24 bytes long
+	if len(data) < 24 {
+		return fmt.Errorf("error decoding process info")
+	}
+	data = bytes.Trim(data, "\x00")
+	i.Pid = binary.LittleEndian.Uint32(data[0:4])
+	i.Ppid = binary.LittleEndian.Uint32(data[4:8])
+	i.Comm = string(data[8:])
+
+	return nil
 }
 
 type goType int

--- a/tests/run_smoke_test.sh
+++ b/tests/run_smoke_test.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 if [[ $EUID -ne 0 ]]; then
-   echo "This script must be run as root" 
+   echo "This script must be run as root"
    exit 1
 fi
 
@@ -19,7 +19,7 @@ test -f $TEST_FUNCTIONS_FILE
 
 echo "[*] Running Weaver with $TEST_FUNCTIONS_FILE"
 
-./bin/weaver -f $TEST_FUNCTIONS_FILE ./bin/tester > $OUTPUT_FILE&
+./bin/weaver --json -f $TEST_FUNCTIONS_FILE ./bin/tester > $OUTPUT_FILE&
 
 OSTER_PID=$!
 


### PR DESCRIPTION
Related to #14 
Added PID, PPID and COMM. 

JSON:
`{"FunctionName":"main.test_uint64_array","Args":[{"Type":"UINT64_ARRAY","Value":"412412456, 1234134"}],"procInfo":{"pid":121841,"ppid":39630,"comm":"tester"}}`

TAB:
```
+-----------------------+--------------+------+-------+-----------+--------+-------+
|     FUNCTION NAME     | ARG POSITION | TYPE | VALUE | PROC NAME |  PID   | PPID  |
+-----------------------+--------------+------+-------+-----------+--------+-------+
| main.test_single_int8 | 0            | INT8 | 1     | tester    | 121892 | 39630 |
+-----------------------+--------------+------+-------+-----------+--------+-------+
```