### PR TITLE
Add 'package' mode, remove table writer

### DIFF
--- a/cmd/weaver/functions_file.go
+++ b/cmd/weaver/functions_file.go
@@ -23,9 +23,9 @@ func read_functions_file(path string) ([]functionTraceContext, error) {
 			continue
 		}
 
-		debugLog("parsing: %s\n", funcString)
-
-		newContext := functionTraceContext{}
+		newContext := functionTraceContext{
+			HasArguments: true,
+		}
 
 		err := parseFunctionAndArgumentTypes(&newContext, funcString)
 		if err != nil {

--- a/cmd/weaver/load_uprobe.go
+++ b/cmd/weaver/load_uprobe.go
@@ -139,98 +139,35 @@ func loadUprobeAndBPFModule(traceContext *functionTraceContext, runtimeContext c
 
 	defer runtimeContext.Err()
 
-	// Load eBPF filter and uprobe
+	// Generate eBPF code via text template and load it into a new module
 	filterText := bpfText(traceContext)
 	bpfModule := bpf.NewModule(filterText, []string{})
 	defer bpfModule.Close()
 
-	uprobeFd, err := bpfModule.LoadUprobe("print_symbol_arg")
+	// Attach the loaded eBPF code to a uprobe'd function specified by the traceContext.FunctionName
+	debugLog("Attaching uprobe to %s\n", traceContext.FunctionName)
+	uprobeFd, err := bpfModule.LoadUprobe("print_symbol_arg") // name of eBPF function
 	if err != nil {
 		return err
 	}
-
-	debugLog("Attaching uprobe to %s\n", traceContext.FunctionName)
 	err = bpfModule.AttachUprobe(traceContext.binaryName, traceContext.FunctionName, uprobeFd, -1)
 	if err != nil {
 		return fmt.Errorf("could not attach uprobe to symbol: %s: %s", "test_function", err.Error())
 	}
 
-	// Set up bpf perf map to use for output
+	// Set up bpf perf map to use for output from eBPF to weaver
 	table := bpf.NewTable(bpfModule.TableId("events"), bpfModule)
 	channel := make(chan []byte)
-
 	perfMap, err := bpf.InitPerfMap(table, channel)
 	if err != nil {
 		return err
 	}
 
-	numberOfArgs := len(traceContext.Arguments)
-	var index int
-	var dataTypeOfValue goType
-	output := output{FunctionName: traceContext.FunctionName}
-	var argOutput = make([]outputArg, numberOfArgs)
-	go func() {
-
-		var valueString string
-		var outputValue outputArg
-		for {
-			// First sent values are process info
-			value := <-channel
-			procInfo := procInfo{}
-			err := procInfo.unmarshalBinary(value)
-			if err == nil {
-				output.ProcInfo = procInfo
-				// if err == nil value was proc info struct, else do
-				// not fetch next value
-				value = <-channel //FIXME: This line shouldn't be called if in package mode
-			}
-
-			if globalMode == PACKAGE_MODE {
-				// no argument parsing in package mode
-				printOutput(output)
-				continue
-			}
-
-			// Determine what type it is for interpretation based on order of value coming in
-			dataTypeOfValue = traceContext.Arguments[index].goType
-
-			// If this argument is an array
-			if traceContext.Arguments[index].ArrayLength > 0 {
-
-				arrayValueString := interpretDataByType(value, dataTypeOfValue)
-
-				for i := 0; i < traceContext.Arguments[index].ArrayLength-1; i++ {
-					value := <-channel
-					valueString = interpretDataByType(value, dataTypeOfValue)
-					arrayValueString = arrayValueString + ", " + valueString
-				}
-				outputValue = outputArg{
-					Type:  goTypeToString[dataTypeOfValue] + "_ARRAY",
-					Value: arrayValueString,
-				}
-
-			} else {
-				// This argument is not an array
-
-				valueString = interpretDataByType(value, dataTypeOfValue)
-
-				outputValue = outputArg{
-					Type:  goTypeToString[dataTypeOfValue],
-					Value: valueString,
-				}
-			}
-
-			argOutput[index] = outputValue
-			index++
-			index = index % numberOfArgs
-
-			if index == 0 {
-				output.Args = argOutput
-				printOutput(output)
-			}
-
-		}
-	}()
+	if globalMode == PACKAGE_MODE {
+		go packageModeListen(traceContext.FunctionName, channel)
+	} else {
+		go functionsFileModeListen(traceContext, channel)
+	}
 
 	wg.Done()
 	perfMap.Start()
@@ -238,6 +175,85 @@ func loadUprobeAndBPFModule(traceContext *functionTraceContext, runtimeContext c
 	perfMap.Stop()
 
 	return nil
+}
+
+func functionsFileModeListen(traceContext *functionTraceContext, rawBytes chan []byte) {
+
+	var (
+		output          = output{FunctionName: traceContext.FunctionName}
+		numberOfArgs    = len(traceContext.Arguments)
+		index           int
+		dataTypeOfValue goType
+		argOutput       = make([]outputArg, numberOfArgs)
+		valueString     string
+		outputValue     outputArg
+	)
+
+	for {
+		value := <-rawBytes
+		procInfo := procInfo{}
+		err := procInfo.unmarshalBinary(value)
+		if err == nil {
+			output.ProcInfo = procInfo
+			// if err == nil value was proc info struct, else do
+			// not fetch next value
+			value = <-rawBytes
+		}
+
+		// Determine what type it is for interpretation based on order of value coming in
+		dataTypeOfValue = traceContext.Arguments[index].goType
+
+		// If this argument is an array
+		if traceContext.Arguments[index].ArrayLength > 0 {
+
+			arrayValueString := interpretDataByType(value, dataTypeOfValue)
+
+			for i := 0; i < traceContext.Arguments[index].ArrayLength-1; i++ {
+				value := <-rawBytes
+				valueString = interpretDataByType(value, dataTypeOfValue)
+				arrayValueString = arrayValueString + ", " + valueString
+			}
+			outputValue = outputArg{
+				Type:  goTypeToString[dataTypeOfValue] + "_ARRAY",
+				Value: arrayValueString,
+			}
+
+		} else {
+			// This argument is not an array
+
+			valueString = interpretDataByType(value, dataTypeOfValue)
+
+			outputValue = outputArg{
+				Type:  goTypeToString[dataTypeOfValue],
+				Value: valueString,
+			}
+		}
+
+		argOutput[index] = outputValue
+		index++
+		index = index % numberOfArgs
+
+		if index == 0 {
+			output.Args = argOutput
+			printOutput(output)
+		}
+	}
+}
+
+// packageModeListen
+func packageModeListen(functionName string, rawBytes chan []byte) {
+	for {
+		value := <-rawBytes
+		procInfo := procInfo{}
+		err := procInfo.unmarshalBinary(value)
+		if err != nil {
+			debugLog("could not read in proccess information: %s\n", err.Error())
+		}
+
+		output := output{FunctionName: functionName}
+		output.ProcInfo = procInfo
+		printOutput(output)
+	}
 }
 
 // interpretDataByType takes raw bytes of a value, and returns a string

--- a/cmd/weaver/output.go
+++ b/cmd/weaver/output.go
@@ -24,7 +24,6 @@ func printOutput(o output) error {
 		return fmt.Errorf("could not marshal output to JSON: %s", err.Error())
 	}
 	fmt.Println(string(b))
-	return nil
 
 	return nil
 }

--- a/cmd/weaver/output.go
+++ b/cmd/weaver/output.go
@@ -4,9 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"sync"
-
-	"github.com/olekukonko/tablewriter"
 )
 
 type output struct {
@@ -20,38 +17,26 @@ type outputArg struct {
 	Value string `json:"value"`
 }
 
-var mutex = &sync.Mutex{}
-
 func printOutput(o output) error {
 
-	if globalJSON {
-		b, err := json.Marshal(o)
-		if err != nil {
-			return fmt.Errorf("could not marshal output to JSON: %s", err.Error())
-		}
-		fmt.Println(string(b))
-		return nil
+	b, err := json.Marshal(o)
+	if err != nil {
+		return fmt.Errorf("could not marshal output to JSON: %s", err.Error())
 	}
-
-	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"Function Name", "Arg Position", "Type", "Value", "Proc Name", "PID", "PPID"})
-	table.SetAlignment(tablewriter.ALIGN_LEFT)
-	for i, arg := range o.Args {
-		line := []string{o.FunctionName, fmt.Sprintf("%d", i), arg.Type, arg.Value, o.ProcInfo.Comm,
-			fmt.Sprintf("%d", o.ProcInfo.Pid), fmt.Sprintf("%d", o.ProcInfo.Ppid)}
-		table.Append(line)
-	}
-
-	// tablewriter doesn't support asynchronous renders
-	mutex.Lock()
-	table.Render()
-	mutex.Unlock()
+	fmt.Println(string(b))
+	return nil
 
 	return nil
 }
 
 func debugLog(format string, a ...interface{}) {
 	if globalDebug {
+		fmt.Fprintf(os.Stderr, "\x1b[96m"+format+"\x1b[0m", a...)
+	}
+}
+
+func debugeBPFLog(format string, a ...interface{}) {
+	if globalDebugeBPF {
 		fmt.Fprintf(os.Stderr, "\x1b[96m"+format+"\x1b[0m", a...)
 	}
 }

--- a/cmd/weaver/read_symbols.go
+++ b/cmd/weaver/read_symbols.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"debug/elf"
+	"strings"
+)
+
+func read_symbols_from_binary(binaryPath string, packagesToTrace []string) ([]functionTraceContext, error) {
+	elfFile, err := elf.Open(binaryPath)
+	if err != nil {
+		return nil, err
+	}
+
+	syms, err := elfFile.Symbols()
+	if err != nil {
+		return nil, err
+	}
+
+	contexts := []functionTraceContext{}
+
+	for _, sym := range syms {
+
+		ok := validateSymbol(sym)
+		if !ok {
+			continue
+		}
+
+		for _, pkg := range packagesToTrace {
+			if strings.HasPrefix(sym.Name, pkg+".") {
+				x := functionTraceContext{
+					binaryName:   binaryPath,
+					FunctionName: sym.Name,
+				}
+				contexts = append(contexts, x)
+			}
+		}
+	}
+
+	return contexts, nil
+}
+
+func validateSymbol(sym elf.Symbol) bool {
+
+	return strings.Count(sym.Name, ".") == 1
+}

--- a/cmd/weaver/read_symbols.go
+++ b/cmd/weaver/read_symbols.go
@@ -29,6 +29,7 @@ func read_symbols_from_binary(binaryPath string, packagesToTrace []string) ([]fu
 			if strings.HasPrefix(sym.Name, pkg+".") {
 				x := functionTraceContext{
 					binaryName:   binaryPath,
+					HasArguments: false,
 					FunctionName: sym.Name,
 				}
 				contexts = append(contexts, x)

--- a/cmd/weaver/types.go
+++ b/cmd/weaver/types.go
@@ -12,7 +12,8 @@ import (
 type functionTraceContext struct {
 	binaryName   string
 	FunctionName string
-	Arguments    []argument
+	HasArguments bool       // used for parsing text template
+	Arguments    []argument `json:",omitempty"`
 }
 
 type argument struct {
@@ -30,6 +31,13 @@ type procInfo struct {
 	Ppid uint32 `json:"ppid,omitempty"`
 	Comm string `json:"comm,omitempty"`
 }
+
+type modeOfOperation uint8
+
+const (
+	PACKAGE_MODE   modeOfOperation = 1
+	FUNC_FILE_MODE modeOfOperation = 2
+)
 
 // unmarshalBinary for procInfo
 func (i *procInfo) unmarshalBinary(data []byte) error {


### PR DESCRIPTION
This adds a 'package' mode, which is default if a functions file is not specified. This will attach uprobes to each function symbol in specified packages (default is just main). Function arguments are extracted for now. This commit also removes the table writer (output is now only JSON).

Signed-off-by: grantseltzer <grantseltzer@gmail.com>