### PR TITLE
Tracing by PID #12 

### DIFF
--- a/cmd/weaver/functions_file.go
+++ b/cmd/weaver/functions_file.go
@@ -25,6 +25,7 @@ func readFunctionsFile(path string) ([]functionTraceContext, error) {
 		}
 
 		newContext := functionTraceContext{
+			Filters:      filters{},
 			HasArguments: true,
 		}
 

--- a/cmd/weaver/load_uprobe.go
+++ b/cmd/weaver/load_uprobe.go
@@ -38,8 +38,15 @@ const bpfWithArgsProgramTextTemplate = `
 		procInfo.ppid = task->real_parent->tgid;
 		bpf_get_current_comm(&procInfo.comm, sizeof(procInfo.comm));
 
-		events.perf_submit(ctx, &procInfo, sizeof(procInfo));
+		{{if gt .Filters.Pid 0}}
+		// apply pid filters
+		if (procInfo.pid != {{ .Filters.Pid }}) {
+			return 0;
+		}
+		{{end}}
 
+		// submit process info
+		events.perf_submit(ctx, &procInfo, sizeof(procInfo));
 
 		{{if eq .HasArguments true}}
 

--- a/cmd/weaver/main.go
+++ b/cmd/weaver/main.go
@@ -156,6 +156,12 @@ func entry(c *cli.Context) error {
 	// Install eBPF program for each function to trace
 	for i := range contexts {
 		wg.Add(1)
+
+		// Apply filters
+		if pid > 0 {
+			contexts[i].Filters.Pid = uint32(pid)
+		}
+
 		contexts[i].binaryName = binaryFullPath
 		go loadUprobeAndBPFModule(&contexts[i], runtimeContext, &wg)
 	}

--- a/cmd/weaver/pid.go
+++ b/cmd/weaver/pid.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+func getProcessRunningStatus(pid int) (*os.Process, error) {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return nil, err
+	}
+
+	//double check if process is running and alive
+	//by sending a signal 0
+	//NOTE : syscall.Signal is not available in Windows
+
+	err = proc.Signal(syscall.Signal(0))
+	if err == nil {
+		return proc, nil
+	}
+
+	if err == syscall.ESRCH {
+		return nil, errors.New("process not running")
+	}
+
+	// default
+	return nil, errors.New("process running but query operation not permitted")
+}
+
+func getBinaryFromPID(pid int) (string, error) {
+	// Weaver should have the rights to read /proc
+
+	// Check if process is running
+	_, err := getProcessRunningStatus(pid)
+	if err != nil {
+		return "", err
+	}
+
+	// Get executable name
+
+	return "", nil
+}

--- a/cmd/weaver/pid.go
+++ b/cmd/weaver/pid.go
@@ -12,7 +12,7 @@ func getBinaryFromPID(pid int) (string, error) {
 	_, err := os.Stat(exe)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return "", errors.New("process not running")
+			return "", fmt.Errorf("%s: binary does not exist: %s", err.Error(), exe)
 		}
 
 		return "", err

--- a/cmd/weaver/pid.go
+++ b/cmd/weaver/pid.go
@@ -2,43 +2,21 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"os"
-	"syscall"
 )
-
-func getProcessRunningStatus(pid int) (*os.Process, error) {
-	proc, err := os.FindProcess(pid)
-	if err != nil {
-		return nil, err
-	}
-
-	//double check if process is running and alive
-	//by sending a signal 0
-	//NOTE : syscall.Signal is not available in Windows
-
-	err = proc.Signal(syscall.Signal(0))
-	if err == nil {
-		return proc, nil
-	}
-
-	if err == syscall.ESRCH {
-		return nil, errors.New("process not running")
-	}
-
-	// default
-	return nil, errors.New("process running but query operation not permitted")
-}
 
 func getBinaryFromPID(pid int) (string, error) {
 	// Weaver should have the rights to read /proc
-
-	// Check if process is running
-	_, err := getProcessRunningStatus(pid)
+	exe := fmt.Sprintf("/proc/%d/exe", pid)
+	_, err := os.Stat(exe)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return "", errors.New("process not running")
+		}
+
 		return "", err
 	}
 
-	// Get executable name
-
-	return "", nil
+	return exe, nil
 }

--- a/cmd/weaver/read_symbols.go
+++ b/cmd/weaver/read_symbols.go
@@ -28,6 +28,7 @@ func read_symbols_from_binary(binaryPath string, packagesToTrace []string) ([]fu
 		for _, pkg := range packagesToTrace {
 			if strings.HasPrefix(sym.Name, pkg+".") {
 				x := functionTraceContext{
+					Filters:      filters{},
 					binaryName:   binaryPath,
 					HasArguments: false,
 					FunctionName: sym.Name,

--- a/cmd/weaver/types.go
+++ b/cmd/weaver/types.go
@@ -9,8 +9,13 @@ import (
 	"strings"
 )
 
+type filters struct {
+	Pid uint32
+}
+
 type functionTraceContext struct {
 	binaryName   string
+	Filters      filters
 	FunctionName string
 	HasArguments bool       // used for parsing text template
 	Arguments    []argument `json:",omitempty"`


### PR DESCRIPTION
Added the ability to filter by PID with `-pid` option. It reads the symbols from `/proc/PID/exe`.

Added a `Filters` struture field to `functionTraceContext`, could be use in the future to add more filters (ie. by user, by comm process name, etc...)
