### PR TITLE
Fix the bug when make

### DIFF
--- a/vendor/github.com/iovisor/gobpf/bcc/module.go
+++ b/vendor/github.com/iovisor/gobpf/bcc/module.go
@@ -258,7 +258,7 @@ func (bpf *Module) attachProbe(evName string, attachType uint32, fnName string, 
 func (bpf *Module) attachUProbe(evName string, attachType uint32, path string, addr uint64, fd, pid int) error {
 	evNameCS := C.CString(evName)
 	binaryPathCS := C.CString(path)
-	res, err := C.bpf_attach_uprobe(C.int(fd), attachType, evNameCS, binaryPathCS, (C.uint64_t)(addr), (C.pid_t)(pid))
+	res, err := C.bpf_attach_uprobe(C.int(fd), attachType, evNameCS, binaryPathCS, (C.uint64_t)(addr), (C.pid_t)(pid), 0)
 	C.free(unsafe.Pointer(evNameCS))
 	C.free(unsafe.Pointer(binaryPathCS))
 


### PR DESCRIPTION
- The solution for [issue55](https://github.com/grantseltzer/weaver/issues/55)
- Change line 261 of `vendor/github.com/iovisor/gobpf/bcc/module.go`, add one parameter according to current code of `gobpf`